### PR TITLE
[MSCellAccessory] fix crash

### DIFF
--- a/MSCellAccessory/MSCellAccessory.m
+++ b/MSCellAccessory/MSCellAccessory.m
@@ -263,7 +263,12 @@
         indexPath = [superTableView indexPathForCell:superTableViewCell];
     }
     
-    [superController tableView:superTableView accessoryButtonTappedForRowWithIndexPath:indexPath];
+    if ([superController respondsToSelector:@selector(tableView:accessoryButtonTappedForRowWithIndexPath:)]) {
+        [superController tableView:superTableView accessoryButtonTappedForRowWithIndexPath:indexPath];
+    }
+    else {
+        NSAssert(0, @"superController must implement tableView:accessoryButtonTappedForRowWithIndexPath:");
+    }
 }
 
 - (void)drawRect:(CGRect)rect


### PR DESCRIPTION
fix crash if controller doesn't implement selector tableView:accessoryButtonTappedForRowWithIndexPath:
